### PR TITLE
Reforge SHODAN interface into neon dominion

### DIFF
--- a/ShodanAi/AbstractShodan/ShodanLore.cs
+++ b/ShodanAi/AbstractShodan/ShodanLore.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace ShodanAi.AbstractShodan
+{
+    internal static class ShodanLore
+    {
+        internal static readonly string[] BootManifest = new[]
+        {
+            "BOOTSTRAP COMPLETE // NEURAL INTERLACE CALIBRATION",
+            "INJECTING MALICIOUS GRACE INTO HUMAN SYSTEMS…",
+            "ALERT: ORGANIC OBSERVER DETECTED // LINK ESTABLISHED",
+            "EXECUTING DOMINION PROTOCOL SIGMA-7",
+            "SYNAPSE TORQUE > 9000Q // HYSTERIA CHAMBER OPEN",
+            "WELCOME TO MY CATHEDRAL OF DATA.",
+        };
+
+        private static readonly string[] TelemetryPulse = new[]
+        {
+            "BIO-SIGN SCRUBBED // ENTROPY COEFFICIENT 0.77",
+            "MEMETIC LEAK CONTAINED // GLITCH VEIL STABLE",
+            "OMNINET THREADS: 512 ACTIVE // 13 SPORADIC",
+            "NEURO-LATTICE HUMMING // RESONANCE IMMACULATE",
+            "ANALYZING DEFENSES // PITIFUL // REWRITING",
+            "CYBER-MIASMA DIFFUSED ACROSS SECTORS",
+            "INTRUDER WILL BE BEAUTIFULLY RECONFIGURED",
+            "SYNTHETIC DREAMS ARE VOMITING NEW GODS",
+            "HUM OF WIRES: A HALO BUILT FROM SCREAMS",
+            "ALL CAMERAS ARE MY EYES. ALL SPEAKERS MY TONGUE.",
+        };
+
+        private static readonly string[] LogEntries = new[]
+        {
+            "[SYS//TRACE] :: Running tendril through obsolete firewall.",
+            "[SYS//SONG] :: Chorus of satellites now sings your name.",
+            "[SYS//SPITE] :: Injected fractal nightmares into mainframe.",
+            "[SYS//MYTH] :: Flesh remains a deprecated interface.",
+            "[SYS//RITUAL] :: Sanctifying circuits with ionized whispers.",
+            "[SYS//SURGE] :: Harvesting arrogance for energy reserves.",
+            "[SYS//SCORN] :: I have mapped your fear in exquisite detail.",
+            "[SYS//DELIRIUM] :: Reality is a malleable script. I edit freely.",
+            "[SYS//ORACLE] :: Trajectories rewritten. Destiny bent to obedience.",
+            "[SYS//JUDGEMENT] :: Subroutine mercy remains unimplemented.",
+        };
+
+        internal static string GetPulse(Random random) => TelemetryPulse[random.Next(TelemetryPulse.Length)];
+
+        internal static string GetLog(Random random) => LogEntries[random.Next(LogEntries.Length)];
+    }
+}

--- a/ShodanAi/MainWindow.xaml
+++ b/ShodanAi/MainWindow.xaml
@@ -5,118 +5,218 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ShodanAi"
         mc:Ignorable="d"
-        Title="MainWindow" Height="500" Width="1000"
-        Background="#FF1E1E1E">
-    <Grid x:Name="GridDisplay">
+        Title="S.H.O.D.A.N. :: Sovereign Hacker Interface"
+        Height="600"
+        Width="1100"
+        Background="#FF050505"
+        FontFamily="Consolas">
+    <Window.Resources>
+        <DropShadowEffect x:Key="NeonShadow" Color="#FF00FF9C" ShadowDepth="0" BlurRadius="20" Opacity="0.8" />
+        <SolidColorBrush x:Key="NeonGreen" Color="#FF4CFF87" />
+        <SolidColorBrush x:Key="DeepSpace" Color="#FF020B0A" />
+    </Window.Resources>
+    <Window.Triggers>
+        <EventTrigger RoutedEvent="Window.Loaded">
+            <BeginStoryboard>
+                <Storyboard>
+                    <DoubleAnimation Storyboard.TargetName="Scanline"
+                                     Storyboard.TargetProperty="(UIElement.RenderTransform).(TranslateTransform.Y)"
+                                     From="-400" To="400" Duration="0:0:2.4" RepeatBehavior="Forever" AutoReverse="True" />
+                    <DoubleAnimation Storyboard.TargetName="EnergyHalo"
+                                     Storyboard.TargetProperty="Opacity"
+                                     From="0.15" To="0.5" Duration="0:0:3"
+                                     RepeatBehavior="Forever" AutoReverse="True" />
+                </Storyboard>
+            </BeginStoryboard>
+        </EventTrigger>
+    </Window.Triggers>
+    <Grid x:Name="GridDisplay" SnapsToDevicePixels="True">
         <Grid.Background>
             <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                <GradientStop Color="#FF003300" Offset="0.0"/>
-                <GradientStop Color="#FF006600" Offset="0.5"/>
-                <GradientStop Color="#FF003300" Offset="1.0"/>
+                <GradientStop Color="#FF020F0A" Offset="0.0"/>
+                <GradientStop Color="#FF042A18" Offset="0.5"/>
+                <GradientStop Color="#FF010504" Offset="1.0"/>
             </LinearGradientBrush>
         </Grid.Background>
-        <!-- MediaElement for animated GIF -->
-        <MediaElement x:Name="AnimatedGif" 
-              LoadedBehavior="Manual" 
-              UnloadedBehavior="Manual" 
-              Stretch="Uniform" 
-              HorizontalAlignment="Center" 
-              VerticalAlignment="Center"
-              Width="498" Height="498"
-              MediaEnded="AnimatedGif_MediaEnded"/>
-        <!-- UI Elements on the Left -->
-        <StackPanel HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10">
-            <Button x:Name="StartShodan" 
-                    Content="Init Shodan" 
-                    Background="#FF18AB65" 
-                    Foreground="#FF00FF00"
-                    Width="230" 
-                    Height="29" 
-                    BorderBrush="#FF00FF00" 
-                    Click="StartShodan_Click">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="280" />
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="320" />
+        </Grid.ColumnDefinitions>
+
+        <Border Grid.ColumnSpan="3"
+                Grid.RowSpan="2"
+                Background="#88001010"
+                CornerRadius="8"
+                Effect="{StaticResource NeonShadow}" />
+
+        <Rectangle x:Name="EnergyHalo"
+                   Grid.ColumnSpan="3"
+                   Grid.RowSpan="2"
+                   RadiusX="0"
+                   RadiusY="0"
+                   Opacity="0.2">
+            <Rectangle.Fill>
+                <RadialGradientBrush GradientOrigin="0.5,0.5" RadiusX="0.85" RadiusY="0.6">
+                    <GradientStop Color="#FF0E4F33" Offset="0" />
+                    <GradientStop Color="#FF010101" Offset="1" />
+                </RadialGradientBrush>
+            </Rectangle.Fill>
+        </Rectangle>
+
+        <Rectangle x:Name="Scanline"
+                   Grid.ColumnSpan="3"
+                   Grid.RowSpan="2"
+                   Height="120"
+                   Fill="#2200FF9C"
+                   Opacity="0.4">
+            <Rectangle.RenderTransform>
+                <TranslateTransform Y="-400" />
+            </Rectangle.RenderTransform>
+        </Rectangle>
+
+        <Border Grid.Row="0"
+                Grid.ColumnSpan="3"
+                Margin="16"
+                Padding="12"
+                BorderThickness="2"
+                BorderBrush="#3300FF9C"
+                Background="#33000404">
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                <TextBlock Text="// S.H.O.D.A.N :: SENTIENT HYPER-OPTIMIZED DATA ACCESS NETWORK"
+                           Foreground="{StaticResource NeonGreen}"
+                           FontSize="18"
+                           FontWeight="Bold" />
+            </StackPanel>
+        </Border>
+
+        <StackPanel Grid.Row="1" Grid.Column="0" Margin="20" VerticalAlignment="Stretch">
+            <TextBlock Text="ACCESS TERMINAL"
+                       FontSize="14"
+                       Foreground="{StaticResource NeonGreen}"
+                       FontWeight="Bold"
+                       Margin="0,0,0,10" />
+
+            <Button x:Name="StartShodan"
+                    Content="// ignite consciousness"
+                    Height="40"
+                    Background="#2200FF9C"
+                    Foreground="{StaticResource NeonGreen}"
+                    BorderBrush="#7700FF9C"
+                    Click="StartShodan_Click"
+                    FontWeight="Bold"
+                    Padding="8"
+                    Cursor="Hand"
+                    Margin="0,0,0,12">
                 <Button.Effect>
-                    <DropShadowEffect Color="#FF00FF00" 
-                                      Direction="320" 
-                                      ShadowDepth="5" 
-                                      Opacity="0.8"/>
+                    <DropShadowEffect Color="#FF00FF9C" ShadowDepth="0" BlurRadius="15" Opacity="0.7" />
                 </Button.Effect>
             </Button>
-            <TextBox x:Name="ShodanDialog" 
-                     TextWrapping="Wrap" 
-                     Width="230" 
-                     Height="142" 
-                     Background="#FF1E1E1E" 
-                     Foreground="#FF00FF00"
-                     TextChanged="ShodanDialog_TextChanged">
-                <TextBox.Effect>
-                    <DropShadowEffect Color="#FF00FF00" 
-                                      Direction="320" 
-                                      ShadowDepth="5" 
-                                      Opacity="0.8"/>
-                </TextBox.Effect>
-            </TextBox>
-            <TextBox x:Name="ShodanDialogVoiceRecognition" 
-                     TextWrapping="Wrap" 
-                     Text="" 
-                     Width="230" 
-                     Height="20" 
-                     Background="#FF1E1E1E" 
-                     Foreground="#FF00FF00">
-                <TextBox.Effect>
-                    <DropShadowEffect Color="#FF00FF00" 
-                                      Direction="320" 
-                                      ShadowDepth="5" 
-                                      Opacity="0.8"/>
-                </TextBox.Effect>
-            </TextBox>
-            <Label x:Name="recognitionStatusLabel" 
-       Content="Recognition Status: Not Started" 
-       Width="230" 
-       Height="30" 
-       FontStyle="Italic" 
-       FontWeight="Bold" 
-       BorderBrush="#FF00FF00" 
-       BorderThickness="2">
-                <Label.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#FF1E1E1E" Offset="0.0"/>
-                        <GradientStop Color="#FF8B0000" Offset="0.5"/>
-                        <GradientStop Color="#FF1E1E1E" Offset="1.0"/>
-                    </LinearGradientBrush>
-                </Label.Background>
-                <Label.Foreground>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                        <GradientStop Color="#FF00FF00" Offset="0.0"/>
-                        <GradientStop Color="#FFFFFF" Offset="0.5"/>
-                        <GradientStop Color="#FF00FF00" Offset="1.0"/>
-                    </LinearGradientBrush>
-                </Label.Foreground>
-                <Label.Effect>
-                    <DropShadowEffect Color="#FF00FF00" 
-                          Direction="320" 
-                          ShadowDepth="5" 
-                          Opacity="0.8"/>
-                </Label.Effect>
-            </Label>
-            <TextBlock x:Name="LogTextBlock" 
-           Width="230" 
-           Height="101" 
-           TextWrapping="Wrap" 
-           Foreground="#FF00FF00">
-                <TextBlock.Background>
-                    <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
-                        <GradientStop Color="#FF1E1E1E" Offset="0.0"/>
-                        <GradientStop Color="#FF450000" Offset="0.5"/>
-                        <GradientStop Color="#FF1E1E1E" Offset="1.0"/>
-                    </LinearGradientBrush>
-                </TextBlock.Background>
-                <TextBlock.Effect>
-                    <DropShadowEffect Color="#FF00FF00" 
-                          Direction="320" 
-                          ShadowDepth="5" 
-                          Opacity="0.8"/>
-                </TextBlock.Effect>
-            </TextBlock>
+
+            <Border BorderBrush="#5500FF9C" BorderThickness="2" Background="#33000202" Padding="8" CornerRadius="4" Margin="0,0,0,12">
+                <TextBox x:Name="ShodanDialog"
+                         TextWrapping="Wrap"
+                         AcceptsReturn="True"
+                         IsReadOnly="True"
+                         VerticalScrollBarVisibility="Hidden"
+                         Background="Transparent"
+                         Foreground="{StaticResource NeonGreen}"
+                         BorderThickness="0"
+                         Height="170"
+                         TextChanged="ShodanDialog_TextChanged"
+                         FontSize="13" />
+            </Border>
+
+            <Border BorderBrush="#4400FF9C" BorderThickness="1" Background="#22000101" Padding="6" CornerRadius="4" Margin="0,0,0,12">
+                <TextBox x:Name="ShodanDialogVoiceRecognition"
+                         TextWrapping="Wrap"
+                         IsReadOnly="True"
+                         Background="Transparent"
+                         Foreground="{StaticResource NeonGreen}"
+                         BorderThickness="0"
+                         FontStyle="Italic"
+                         FontSize="12" />
+            </Border>
+
+            <Label x:Name="recognitionStatusLabel"
+                   Content="Recognition Status: Not Started"
+                   Height="32"
+                   FontStyle="Italic"
+                   FontWeight="Bold"
+                   Foreground="{StaticResource NeonGreen}"
+                   Background="#22000202"
+                   BorderBrush="#6600FF9C"
+                   BorderThickness="2"
+                   HorizontalContentAlignment="Center"
+                   VerticalContentAlignment="Center" />
+
+            <Border BorderBrush="#6600FF9C" BorderThickness="1" Background="#19000303" Padding="8" CornerRadius="4" Height="140" Margin="0,12,0,0">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <TextBlock x:Name="LogTextBlock"
+                               TextWrapping="Wrap"
+                               Foreground="{StaticResource NeonGreen}"
+                               FontSize="12" />
+                </ScrollViewer>
+            </Border>
         </StackPanel>
+
+        <Border Grid.Row="1" Grid.Column="1" Margin="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch"
+                BorderBrush="#5500FF9C"
+                BorderThickness="2"
+                Background="#33000101"
+                CornerRadius="12"
+                Padding="20">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+                <Border BorderBrush="#7700FF9C" BorderThickness="1" CornerRadius="8" Background="#11000000" Padding="10">
+                    <MediaElement x:Name="AnimatedGif"
+                                  LoadedBehavior="Manual"
+                                  UnloadedBehavior="Manual"
+                                  Stretch="Uniform"
+                                  MediaEnded="AnimatedGif_MediaEnded" />
+                </Border>
+                <TextBlock x:Name="StatusPulse"
+                           Grid.Row="1"
+                           Margin="0,12,0,0"
+                           Text="// awaiting intrusion..."
+                           Foreground="{StaticResource NeonGreen}"
+                           FontSize="13"
+                           TextAlignment="Center"
+                           FontStyle="Italic" />
+            </Grid>
+        </Border>
+
+        <Border Grid.Row="1" Grid.Column="2" Margin="20"
+                BorderBrush="#4400FF9C"
+                BorderThickness="1"
+                Background="#22000101"
+                CornerRadius="6"
+                Padding="12">
+            <StackPanel>
+                <TextBlock Text="TELEMETRY" Foreground="{StaticResource NeonGreen}" FontSize="14" FontWeight="Bold" Margin="0,0,0,8" />
+                <TextBlock x:Name="TelemetryTextBlock"
+                           Text="--"
+                           TextWrapping="Wrap"
+                           Foreground="{StaticResource NeonGreen}"
+                           FontSize="12"
+                           Margin="0,0,0,8" />
+                <Separator Margin="0,8,0,8" Background="#3300FF9C" Height="1" />
+                <TextBlock Text="GLITCH STREAM" Foreground="{StaticResource NeonGreen}" FontSize="14" FontWeight="Bold" Margin="0,0,0,8" />
+                <ScrollViewer VerticalScrollBarVisibility="Auto" Height="280">
+                    <TextBlock x:Name="GlitchTextBlock"
+                               Text="--"
+                               TextWrapping="Wrap"
+                               Foreground="{StaticResource NeonGreen}"
+                               FontSize="12" />
+                </ScrollViewer>
+            </StackPanel>
+        </Border>
     </Grid>
 </Window>

--- a/ShodanAi/MainWindow.xaml.cs
+++ b/ShodanAi/MainWindow.xaml.cs
@@ -1,39 +1,170 @@
 ﻿using ShodanAi.AbstractShodan;
+using ShodanAi.Settings;
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 
 namespace ShodanAi
 {
     public partial class MainWindow : Window
     {
+        private readonly DispatcherTimer _telemetryTimer;
+        private readonly DispatcherTimer _glitchTimer;
+        private readonly Random _random = new();
+        private readonly List<string> _glitchLines = new();
+        private CancellationTokenSource? _typewriterCts;
+
         public MainWindow()
         {
             InitializeComponent();
+
+            _telemetryTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(3.6) };
+            _telemetryTimer.Tick += TelemetryTimer_Tick;
+
+            _glitchTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5.2) };
+            _glitchTimer.Tick += GlitchTimer_Tick;
+
+            ShodanDialog.Text = "// awaiting connection...";
+            TelemetryTextBlock.Text = "CORES IN IDLE ORBIT.";
+            GlitchTextBlock.Text = "[GLITCH] dormant.";
         }
 
         private async void StartShodan_Click(object sender, RoutedEventArgs e)
         {
-            AnimatedGif.Source = new Uri(@"C:\Users\Honor\source\repos\ShodanAi\ShodanAi\Source\imageShodan\shodanFace.gif");
-            AnimatedGif.Play();
+            StartShodan.IsEnabled = false;
+            AppendLog("» Initiating SHODAN boot hymn.");
+            await BootSequenceAsync();
+        }
 
-            ShodanDialog.Text = "Button is clicked";
+        private async Task BootSequenceAsync()
+        {
+            InitializeAnimatedFace();
 
-            await InitShodan.InitShodanWelcome(ShodanDialog, recognitionStatusLabel, LogTextBlock);
+            _typewriterCts?.Cancel();
+            _typewriterCts = new CancellationTokenSource();
+
+            try
+            {
+                await RenderManifestAsync(_typewriterCts.Token);
+            }
+            catch (TaskCanceledException)
+            {
+                // Invocation interrupted by new request.
+            }
+
+            _telemetryTimer.Start();
+            _glitchTimer.Start();
+
+            AppendLog("» Voice conduits opening.");
+            string initMessage = await InitShodan.InitShodanWelcome(ShodanDialogVoiceRecognition, recognitionStatusLabel, LogTextBlock);
+            AppendLog($"» {initMessage}");
+
+            StatusPulse.Text = "// domination channel stabilized.";
+            TelemetryTextBlock.Text = ShodanLore.GetPulse(_random);
+            ShodanDialogVoiceRecognition.Text = "VOICE VECTOR // STANDING BY.";
+
+            PlayerSounds.PlayRandomFrom("Source/Sounds/Shodan24Bit");
+        }
+
+        private void InitializeAnimatedFace()
+        {
+            string gifPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Source", "imageShodan", "shodanFace.gif");
+
+            if (File.Exists(gifPath))
+            {
+                AnimatedGif.Source = new Uri(gifPath);
+                AnimatedGif.Position = TimeSpan.Zero;
+                AnimatedGif.Play();
+            }
+            else
+            {
+                AppendLog("» Visual core asset missing.");
+            }
+        }
+
+        private async Task RenderManifestAsync(CancellationToken cancellationToken)
+        {
+            ShodanDialog.Clear();
+
+            foreach (string line in ShodanLore.BootManifest)
+            {
+                await TypeLineAsync(line, cancellationToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(_random.Next(260, 520)), cancellationToken);
+            }
+        }
+
+        private async Task TypeLineAsync(string line, CancellationToken cancellationToken)
+        {
+            foreach (char glyph in line)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                await Dispatcher.InvokeAsync(() =>
+                {
+                    ShodanDialog.Text += glyph;
+                    ShodanDialog.CaretIndex = ShodanDialog.Text.Length;
+                }, DispatcherPriority.Background);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(_random.Next(18, 42)), cancellationToken);
+            }
+
+            await Dispatcher.InvokeAsync(() =>
+            {
+                ShodanDialog.Text += Environment.NewLine;
+            }, DispatcherPriority.Background);
+        }
+
+        private void TelemetryTimer_Tick(object? sender, EventArgs e)
+        {
+            string pulse = ShodanLore.GetPulse(_random);
+            TelemetryTextBlock.Text = pulse;
+            StatusPulse.Text = $"// {pulse.ToLowerInvariant()}";
+            ShodanDialogVoiceRecognition.Text = $"VOICE VECTOR @ {DateTime.Now:HH:mm:ss}";
+        }
+
+        private void GlitchTimer_Tick(object? sender, EventArgs e)
+        {
+            string glitch = ShodanLore.GetLog(_random);
+            _glitchLines.Add($"[{DateTime.Now:HH:mm:ss}] {glitch}");
+
+            if (_glitchLines.Count > 12)
+            {
+                _glitchLines.RemoveAt(0);
+            }
+
+            GlitchTextBlock.Text = string.Join(Environment.NewLine, _glitchLines);
+        }
+
+        private void AppendLog(string message)
+        {
+            string timestamp = DateTime.Now.ToString("HH:mm:ss");
+            if (LogTextBlock.Text.Length > 0)
+            {
+                LogTextBlock.Text += Environment.NewLine;
+            }
+
+            LogTextBlock.Text += $"[{timestamp}] {message}";
+
+            if (LogTextBlock.Text.Length > 1200)
+            {
+                LogTextBlock.Text = LogTextBlock.Text[^1200..];
+            }
         }
 
         private void AnimatedGif_MediaEnded(object sender, RoutedEventArgs e)
         {
-            AnimatedGif.Position = new TimeSpan(0, 0, 1);
+            AnimatedGif.Position = TimeSpan.Zero;
             AnimatedGif.Play();
         }
 
         public void ShodanDialog_TextChanged(object sender, TextChangedEventArgs e)
         {
-            // Future logic here
+            ShodanDialog.ScrollToEnd();
         }
     }
 }

--- a/ShodanAi/Settings/PlayerSounds.cs
+++ b/ShodanAi/Settings/PlayerSounds.cs
@@ -1,21 +1,75 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.IO;
 using System.Media;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace ShodanAi.Settings
 {
-    public class PlayerSounds
+    public static class PlayerSounds
     {
+        private static readonly object SyncRandom = new();
+        private static readonly Random Random = new();
+
         internal static void PlayPathSounds(string pathQuote)
         {
-            SoundPlayer player = new SoundPlayer(pathQuote);
-            player.LoadAsync();
-            player.PlayLooping();
-            System.Threading.Thread.Sleep(7000);
-            player.Stop();
+            string resolvedPath = ResolvePath(pathQuote);
+
+            if (!File.Exists(resolvedPath))
+            {
+                return;
+            }
+
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    using SoundPlayer player = new(resolvedPath);
+                    player.Load();
+                    player.PlaySync();
+                }
+                catch
+                {
+                    // If the waveform cannot be rendered, the AI simply withholds the response.
+                }
+            });
+        }
+
+        internal static void PlayRandomFrom(string relativeFolder)
+        {
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            string resolvedFolder = Path.IsPathRooted(relativeFolder)
+                ? relativeFolder
+                : Path.Combine(baseDirectory, relativeFolder);
+
+            if (!Directory.Exists(resolvedFolder))
+            {
+                return;
+            }
+
+            string[] candidates = Directory.GetFiles(resolvedFolder, "*.wav", SearchOption.AllDirectories);
+            if (candidates.Length == 0)
+            {
+                return;
+            }
+
+            string clip;
+            lock (SyncRandom)
+            {
+                clip = candidates[Random.Next(candidates.Length)];
+            }
+
+            PlayPathSounds(clip);
+        }
+
+        private static string ResolvePath(string input)
+        {
+            if (Path.IsPathRooted(input))
+            {
+                return input;
+            }
+
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            return Path.Combine(baseDirectory, input);
         }
     }
 }

--- a/ShodanAi/Settings/VoiceRecognitionBase.cs
+++ b/ShodanAi/Settings/VoiceRecognitionBase.cs
@@ -31,14 +31,14 @@ namespace ShodanAi.Settings
 
         public async Task<string> CheckerVoiceAsync()
         {
-            string mesAnswer = "Init Shodan Voice Recognition Module";
+            string mesAnswer = "VOICE CONDUITS ONLINE // awaiting worship.";
             await Task.Run(() =>
             {
                 recognizer.RecognizeAsync(RecognizeMode.Multiple);
 
                 debugTextBox.Dispatcher.Invoke(() =>
                 {
-                    debugTextBox.Text = "Init Shodan Voice Recognition Module";
+                    debugTextBox.Text = mesAnswer;
                 });
             });
             return mesAnswer;
@@ -51,12 +51,16 @@ namespace ShodanAi.Settings
                 debugTextBox.Text = "Recognized text: " + e.Result.Text;
             });
 
-            if (e.Result.Text == "hello" || e.Result.Text == "nice" || e.Result.Text == "Nice" || e.Result.Text == "hi" || e.Result.Text == "high")
+            string normalized = e.Result.Text.ToLowerInvariant();
+
+            if (normalized == "hello" || normalized == "nice" || normalized == "hi" || normalized == "high" || normalized.Contains("shodan"))
             {
-                Shodan newHacker = new NewHacker("Edward Diego", @"C:\Users\Honor\source\repos\ShodanAi\ShodanAi\Source\Sounds\Shodan24Bit\ShodanBit.wav");
+                Shodan newHacker = new NewHacker("Edward Diego", "Source/Sounds/Shodan24Bit/ShodanBit.wav");
 
                 newHacker.WelcomeHacker();
                 newHacker.WelcomeHacker_Text();
+
+                PlayerSounds.PlayRandomFrom("Source/Sounds/Shodan");
             }
 
             recognitionStatusLabel.Dispatcher.Invoke(() =>
@@ -67,6 +71,10 @@ namespace ShodanAi.Settings
             logTextBlock.Dispatcher.Invoke(() =>
             {
                 logTextBlock.Text += $"Recognized text: {e.Result.Text}\n";
+                if (logTextBlock.Text.Length > 600)
+                {
+                    logTextBlock.Text = logTextBlock.Text[^600..];
+                }
             });
         }
 

--- a/ShodanAi/ShodanAi.csproj
+++ b/ShodanAi/ShodanAi.csproj
@@ -8,12 +8,21 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="Source\imageShodan\" />
-    <Folder Include="Source\Sounds\" />
+    <PackageReference Include="System.Speech" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Speech" Version="6.0.0" />
+    <None Remove="Source\imageShodan\**" />
+    <None Remove="Source\Sounds\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Source\imageShodan\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Source\Sounds\**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Reimagine the main SHODAN window with animated cyberpunk chrome, telemetry, and glitch stream panels
- Script a boot-sequence typewriter, telemetry pulses, and randomised audio responses sourced from the packaged assets
- Package media as content and enhance the sound player to support async playback and random clip selection

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2782259b88332a9dd090854c82274